### PR TITLE
Update gitignore and remove *.aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Based on GitHub gitignore for LabVIEW, found here:
+# https://github.com/github/gitignore/blob/main/LabVIEW.gitignore
+
 # Libraries
 *.lvlibp
 *.llb
@@ -11,8 +14,13 @@
 # Executables
 *.exe
 
-# Computer-specific settings
+# Metadata
+*.aliases
 *.lvlps
+.cache/
+
+# Builds
+builds/
 
 # Project-specific files
 logs/

--- a/Mock Pump Controller.aliases
+++ b/Mock Pump Controller.aliases
@@ -1,2 +1,0 @@
-[My Computer]
-My Computer = "192.168.122.245"


### PR DESCRIPTION
## Description

LabVIEW's `*.aliases` are computer-specific and should not be committed. I have updated the gitignore here and removed the aliases file from the repo.
